### PR TITLE
Add PDF quote generation and download option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas>=2.0.0
 gspread>=5.12.0
 pytz>=2023.3
 google-auth>=2.0.0
+pdfkit>=1.0.0
+reportlab>=3.6.0


### PR DESCRIPTION
## Summary
- Generate a hidden HTML quote summary and convert it to PDF using pdfkit or reportlab
- Add download button for quote PDFs and attach PDFs to emailed quotes
- Include pdfkit and reportlab in project requirements

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0500a2130832c9a6c58618a2467ca